### PR TITLE
fix(planframe): implement missing string expression nodes (#2)

### DIFF
--- a/python/pydantable/planframe_adapter/expr.py
+++ b/python/pydantable/planframe_adapter/expr.py
@@ -178,17 +178,35 @@ def _to_pyd_expr(expr: Any, *, schema_fields: dict[str, Any]) -> Any:
         return _to_pyd_expr(expr.value, schema_fields=schema_fields).log()
 
     if isinstance(expr, pf.StrContains):
-        return _to_pyd_expr(expr.value, schema_fields=schema_fields).str_contains(
-            expr.pattern, literal=expr.literal
-        )
+        v = _to_pyd_expr(expr.value, schema_fields=schema_fields)
+        if expr.literal:
+            return v.str_contains(expr.pattern)
+        return v.str_contains_pat(expr.pattern, literal=False)
     if isinstance(expr, pf.StrStartsWith):
-        return _to_pyd_expr(expr.value, schema_fields=schema_fields).str_starts_with(
+        return _to_pyd_expr(expr.value, schema_fields=schema_fields).starts_with(
             expr.prefix
         )
     if isinstance(expr, pf.StrEndsWith):
-        return _to_pyd_expr(expr.value, schema_fields=schema_fields).str_ends_with(
+        return _to_pyd_expr(expr.value, schema_fields=schema_fields).ends_with(
             expr.suffix
         )
+
+    if isinstance(expr, pf.StrLower):
+        return _to_pyd_expr(expr.value, schema_fields=schema_fields).lower()
+    if isinstance(expr, pf.StrUpper):
+        return _to_pyd_expr(expr.value, schema_fields=schema_fields).upper()
+    if isinstance(expr, pf.StrLen):
+        return _to_pyd_expr(expr.value, schema_fields=schema_fields).char_length()
+    if isinstance(expr, pf.StrStrip):
+        return _to_pyd_expr(expr.value, schema_fields=schema_fields).strip()
+    if isinstance(expr, pf.StrReplace):
+        return _to_pyd_expr(expr.value, schema_fields=schema_fields).str_replace(
+            expr.pattern,
+            expr.replacement,
+            literal=expr.literal,
+        )
+    if isinstance(expr, pf.StrSplit):
+        return _to_pyd_expr(expr.value, schema_fields=schema_fields).str_split(expr.by)
 
     raise NotImplementedError(
         f"Unsupported PlanFrame expression node: {type(expr).__name__}"

--- a/tests/dataframe/test_planframe_adapter_string_exprs.py
+++ b/tests/dataframe/test_planframe_adapter_string_exprs.py
@@ -1,0 +1,102 @@
+"""PlanFrame string expression lowering via ``planframe_adapter.expr`` (issue #2)."""
+
+from __future__ import annotations
+
+from planframe.expr import api as pf
+from pydantable import DataFrameModel
+from pydantable.planframe_adapter.execute import execute_frame
+
+
+class _Strings(DataFrameModel):
+    s: str
+
+
+class _StringsOpt(DataFrameModel):
+    s: str | None
+
+
+def _run_with_column(m: DataFrameModel, pf_expr: object) -> dict[str, list[object]]:
+    out = execute_frame(m._pf.with_column("out", pf_expr))
+    return out.to_dict()
+
+
+def test_planframe_str_lower() -> None:
+    d = _run_with_column(_Strings({"s": ["Hello", "WORLD"]}), pf.StrLower(pf.col("s")))
+    assert d["out"] == ["hello", "world"]
+
+
+def test_planframe_str_upper() -> None:
+    d = _run_with_column(_Strings({"s": ["Hello", "WORLD"]}), pf.StrUpper(pf.col("s")))
+    assert d["out"] == ["HELLO", "WORLD"]
+
+
+def test_planframe_str_len() -> None:
+    d = _run_with_column(_Strings({"s": ["hello", "world"]}), pf.StrLen(pf.col("s")))
+    assert d["out"] == [5, 5]
+
+
+def test_planframe_str_strip() -> None:
+    d = _run_with_column(
+        _Strings({"s": ["  ab  ", "  cd  "]}),
+        pf.StrStrip(pf.col("s")),
+    )
+    assert d["out"] == ["ab", "cd"]
+
+
+def test_planframe_str_replace_literal() -> None:
+    d = _run_with_column(
+        _Strings({"s": ["abc", "def"]}),
+        pf.StrReplace(pf.col("s"), pattern="a", replacement="x", literal=True),
+    )
+    assert d["out"] == ["xbc", "def"]
+
+
+def test_planframe_str_split() -> None:
+    d = _run_with_column(
+        _Strings({"s": ["a,b", "c,d"]}),
+        pf.StrSplit(pf.col("s"), by=","),
+    )
+    assert d["out"] == [["a", "b"], ["c", "d"]]
+
+
+def test_planframe_str_len_nullable_string() -> None:
+    m = _StringsOpt({"s": ["ab", None]})
+    out = execute_frame(m._pf.with_column("n", pf.StrLen(pf.col("s"))))
+    assert out.to_dict()["n"] == [2, None]
+
+
+def test_planframe_str_replace_regex_mode() -> None:
+    """PlanFrame ``literal=False`` maps to pydantable regex replace."""
+    d = _run_with_column(
+        _Strings({"s": ["abc123", "x99y"]}),
+        pf.StrReplace(pf.col("s"), pattern=r"\d+", replacement="", literal=False),
+    )
+    assert d["out"] == ["abc", "xy"]
+
+
+def test_planframe_str_contains_literal_and_regex() -> None:
+    d_lit = _run_with_column(
+        _Strings({"s": ["abc", "def"]}),
+        pf.StrContains(pf.col("s"), "b", literal=True),
+    )
+    assert d_lit["out"] == [True, False]
+
+    d_re = _run_with_column(
+        _Strings({"s": ["a1", "b2"]}),
+        pf.StrContains(pf.col("s"), r"\d", literal=False),
+    )
+    assert d_re["out"] == [True, True]
+
+
+def test_planframe_str_starts_ends_with() -> None:
+    d_s = _run_with_column(
+        _Strings({"s": ["abc", "xyz"]}),
+        pf.StrStartsWith(pf.col("s"), "a"),
+    )
+    assert d_s["out"] == [True, False]
+
+    d_e = _run_with_column(
+        _Strings({"s": ["abc", "xyz"]}),
+        pf.StrEndsWith(pf.col("s"), "z"),
+    )
+    assert d_e["out"] == [False, True]


### PR DESCRIPTION
## Summary
Implements PlanFrame `StrLower`, `StrUpper`, `StrLen`, `StrStrip`, `StrReplace`, and `StrSplit` lowering in `planframe_adapter/expr.py`, mapping each to the matching pydantable `Expr` string API.

Also corrects `StrContains`, `StrStartsWith`, and `StrEndsWith` to use the actual `Expr` surface (`str_contains` / `str_contains_pat`, `starts_with`, `ends_with`).

## Tests
- New `tests/dataframe/test_planframe_adapter_string_exprs.py`: materializes PlanFrame pipelines via `execute_frame` for each node (plus nullable `StrLen`, regex `StrReplace`, and fixed contains/starts/ends).

## Acceptance
- No `NotImplementedError` for the six nodes in the issue.
- `ruff` + `ty` + targeted `pytest -n 10` run clean locally.

Fixes https://github.com/eddiethedean/pydantable/issues/2