### PR TITLE
fix(planframe): implement DtYear/DtMonth/DtDay lowering (#3)

### DIFF
--- a/python/pydantable/planframe_adapter/expr.py
+++ b/python/pydantable/planframe_adapter/expr.py
@@ -208,6 +208,14 @@ def _to_pyd_expr(expr: Any, *, schema_fields: dict[str, Any]) -> Any:
     if isinstance(expr, pf.StrSplit):
         return _to_pyd_expr(expr.value, schema_fields=schema_fields).str_split(expr.by)
 
+    # Datetime / date parts
+    if isinstance(expr, pf.DtYear):
+        return _to_pyd_expr(expr.value, schema_fields=schema_fields).dt_year()
+    if isinstance(expr, pf.DtMonth):
+        return _to_pyd_expr(expr.value, schema_fields=schema_fields).dt_month()
+    if isinstance(expr, pf.DtDay):
+        return _to_pyd_expr(expr.value, schema_fields=schema_fields).dt_day()
+
     raise NotImplementedError(
         f"Unsupported PlanFrame expression node: {type(expr).__name__}"
     )

--- a/tests/dataframe/test_planframe_adapter_datetime_exprs.py
+++ b/tests/dataframe/test_planframe_adapter_datetime_exprs.py
@@ -1,0 +1,43 @@
+"""PlanFrame datetime extraction lowering via ``planframe_adapter.expr`` (issue #3)."""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+
+from planframe.expr import api as pf
+from pydantable import DataFrameModel
+from pydantable.planframe_adapter.execute import execute_frame
+
+
+class _Dates(DataFrameModel):
+    d: date
+
+
+class _Datetimes(DataFrameModel):
+    ts: datetime
+
+
+def _run_with_column(m: DataFrameModel, pf_expr: object) -> dict[str, list[object]]:
+    out = execute_frame(m._pf.with_column("out", pf_expr))
+    return out.to_dict()
+
+
+def test_planframe_dt_year_month_day_on_date() -> None:
+    m = _Dates({"d": [date(2024, 3, 15), date(2025, 12, 1)]})
+    assert _run_with_column(m, pf.DtYear(pf.col("d")))["out"] == [2024, 2025]
+    assert _run_with_column(m, pf.DtMonth(pf.col("d")))["out"] == [3, 12]
+    assert _run_with_column(m, pf.DtDay(pf.col("d")))["out"] == [15, 1]
+
+
+def test_planframe_dt_year_month_day_on_datetime() -> None:
+    m = _Datetimes(
+        {
+            "ts": [
+                datetime(2024, 7, 20, 14, 30, 0),
+                datetime(2023, 1, 2, 0, 0, 0),
+            ]
+        }
+    )
+    assert _run_with_column(m, pf.DtYear(pf.col("ts")))["out"] == [2024, 2023]
+    assert _run_with_column(m, pf.DtMonth(pf.col("ts")))["out"] == [7, 1]
+    assert _run_with_column(m, pf.DtDay(pf.col("ts")))["out"] == [20, 2]


### PR DESCRIPTION
## Summary
Lower PlanFrame `DtYear`, `DtMonth`, and `DtDay` in `planframe_adapter/expr.py` to pydantable `Expr.dt_year()` / `dt_month()` / `dt_day()` (existing Rust temporal-part ops).

## Tests
- `tests/dataframe/test_planframe_adapter_datetime_exprs.py`: `date` and `datetime` columns via `execute_frame`.

Fixes https://github.com/eddiethedean/pydantable/issues/3